### PR TITLE
Price rounding logic needs to be applied uniformly

### DIFF
--- a/uc_bitpay/uc_bitpay.module
+++ b/uc_bitpay/uc_bitpay.module
@@ -889,12 +889,5 @@ function _uc_bitpay_currency_array() {
 }
 
 function _uc_bitpay_round_price($price) {
-  // I don't see any way to get the precision
-  // right without doing it by hand, so...
-  $prec = variable_get('uc_currency_prec', 2);
-  $factor = pow(10, $prec);
-  $large_price = $price * $factor;
-  $price = floor($large_price + 0.5) / $factor; // round up
-
-  return $price;
+  return number_format($price, variable_get('uc_currency_prec', 2), '.', '');
 }


### PR DESCRIPTION
Prices in Ubercart, especially those involving taxes, can often go out to more than 2 decimal places.  uc_bitpay module accounted for this inconsistently, rounding order totals in some places but not in others.

This created a significant bug on the order review screen which effectively created a new invoice every time cart-review was invoked.  This made it impossible to complete such orders as the invoice ID changed every time the customer hit the "Submit" button.  It also caused the customer's payment to become "lost"--e.g. disconnected from the order.

This pull request consolidates all rounding logic to a single function (uc_bitpay_round_price()) and ensures it is applied consistently.
