### PR TITLE
Added check for invoice id

### DIFF
--- a/uc_bitpay/uc_bitpay.module
+++ b/uc_bitpay/uc_bitpay.module
@@ -411,7 +411,7 @@ function uc_payment_method_bitpay($op, &$order) {
         $resp = uc_bitpay_create_invoice($order);
         
         // basic acid test to verify it didn't obviously fail
-        if (is_array($resp)) {
+        if (is_array($resp) && isset($resp['id'])) {
           // if successful, save the invoice data locally
           if (variable_get('uc_bitpay_notify_email_active', FALSE)) {
             $notify_email = variable_get('uc_bitpay_notify_email', '');


### PR DESCRIPTION
This fixes a bug where error messages returned from BitPay were passing the is_array() check and allowing the new invoice creation process to continue.
